### PR TITLE
Added back default markup

### DIFF
--- a/includes/ucf-post-list-common.php
+++ b/includes/ucf-post-list-common.php
@@ -109,39 +109,80 @@ if ( !class_exists( 'UCF_Post_List_Common' ) ) {
 			ob_start();
 
 			// Post List Before
-			$layout_before = apply_filters( 'ucf_post_list_display_' . $layout . '_before', '', $posts, $atts );
+			$layout_before = apply_filters(
+				'ucf_post_list_display_' . $layout . '_before',
+				ucf_post_list_display_default_before( '', $posts, $atts ),
+				$posts,
+				$atts
+			);
 			echo $layout_before;
 
 			// Post List Title
-			$layout_title = apply_filters( 'ucf_post_list_display_' . $layout . '_title', '', $posts, $atts );
+			$layout_title = apply_filters(
+				'ucf_post_list_display_' . $layout . '_title',
+				ucf_post_list_display_default_title( '', $posts, $atts ),
+				$posts,
+				$atts
+			);
 			echo $layout_title;
 
 			if ( $atts['display_search'] ) {
 
 				// Search Before
-				$search_before = apply_filters( 'ucf_post_list_search_before', '', $posts, $atts );
+				$search_before = apply_filters(
+					'ucf_post_list_search_before',
+					ucf_post_list_search_before( '', $posts, $atts ),
+					$posts,
+					$atts
+				);
 				echo $search_before;
 
 				// Search Content
-				$search_content = apply_filters( 'ucf_post_list_search', '', $posts, $atts );
+				$search_content = apply_filters(
+					'ucf_post_list_search',
+					ucf_post_list_search( '', $posts, $atts ),
+					$posts,
+					$atts
+				);
 				echo $search_content;
 
 				// Search Script
-				$search_script = apply_filters( 'ucf_post_list_search_script', '', $posts, $atts, $typeahead_settings );
+				$search_script = apply_filters(
+					'ucf_post_list_search_script',
+					ucf_post_list_search_script( '', $posts, $atts, $typeahead_settings ),
+					$posts,
+					$atts,
+					$typeahead_settings
+				);
 				echo $search_script;
 
 				// Search After
-				$search_after = apply_filters( 'ucf_post_list_search_after', '', $posts, $atts );
+				$search_after = apply_filters(
+					'ucf_post_list_search_after',
+					ucf_post_list_search_after( '', $posts, $atts ),
+					$posts,
+					$atts
+				);
 				echo $search_after;
 
 			}
 
 			// Post List Content/Loop
-			$layout_content = apply_filters( 'ucf_post_list_display_' . $layout, '', $posts, $atts );
+			$layout_content = apply_filters(
+				'ucf_post_list_display_' . $layout,
+				ucf_post_list_display_default( '', $posts, $atts ),
+				$posts,
+				$atts
+			);
 			echo $layout_content;
 
 			// Post List After
-			$layout_after = apply_filters( 'ucf_post_list_display_' . $layout . '_after', '', $posts, $atts );
+			$layout_after = apply_filters(
+				'ucf_post_list_display_' . $layout . '_after',
+				ucf_post_list_display_default_after( '', $posts, $atts ),
+				$posts,
+				$atts
+			);
 			echo $layout_after;
 
 			return ob_get_clean();


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-Post-List-Shortcode.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Post-List-Shortcode/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Added back in default markup as input to the dynamic filters.

**Motivation and Context**
This adds a layer of backwards compatibility to themes that provide custom layouts. Since each filter had a default value, layouts did not have to include a function for _every_ filter and could utilize the default markup (like the closing `</div>` from the `after` filter).

**How Has This Been Tested?**
Change is available for review in dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
